### PR TITLE
Add --group-by parameter to specify a unique tag value shared by a raid group

### DIFF
--- a/bin/ec2-rotate-volume-snapshots
+++ b/bin/ec2-rotate-volume-snapshots
@@ -11,7 +11,8 @@ $opts = {
   :pattern => nil,
   :by_tags => nil,
   :dry_run => false,
-  :backoff_limit => 0
+  :backoff_limit => 0,
+  :group_by => nil
 }
 
 $time_periods = {
@@ -37,6 +38,10 @@ end
 def rotate_em(snapshots)
   # poor man's way to get a deep copy of our time_periods definition hash
   periods = Marshal.load(Marshal.dump($time_periods))
+  if $opts[:group_by]
+    group_bys = []
+    group_by_key = $opts[:group_by]
+  end
   
   snapshots.each do |snapshot|
     time = Time.parse(snapshot[:aws_started_at])
@@ -59,9 +64,16 @@ def rotate_em(snapshots)
         if !keeping.key?(time_string) && keeping.length < keep
           keep_reason = period
           keeping[time_string] = snapshot
+          if group_by_key
+            group_bys.push(snapshot[:tags][group_by_key])
+          end
         end
         break
       end
+    end
+
+    if group_by_key && keep_reason.nil? && group_bys.include?(snapshot[:tags][group_by_key])
+      keep_reason = "volume is associated with others by #{group_by_key}=#{snapshot[:tags][group_by_key]}"
     end
     
     if keep_reason.nil? && snapshot == snapshots.last && $opts[:keep_last]
@@ -146,6 +158,10 @@ OptionParser.new do |o|
 
   o.on("--dry-run", "Shows what would happen without doing anything") do |v|
     $opts[:dry_run] = true
+  end
+
+  o.on("--group-by TAG", "Saves any volumes that have the same value for this tag key") do |v|
+    $opts[:group_by] = v
   end
 end.parse!
 

--- a/bin/ec2-rotate-volume-snapshots
+++ b/bin/ec2-rotate-volume-snapshots
@@ -47,7 +47,7 @@ def rotate_em(snapshots)
     time = Time.parse(snapshot[:aws_started_at])
     snapshot_id = snapshot[:aws_id]
     description = snapshot[:aws_description]
-    keep_reason = nil
+    snapshot[:keep_reason] = nil
     
     if $opts[:pattern] && description !~ /#{$opts[:pattern]}/
       puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Skipping snapshot with description #{description}"
@@ -62,7 +62,7 @@ def rotate_em(snapshots)
       time_string = time.strftime period_info[:format]
       if Time.now - time < keep * period_info[:seconds]
         if !keeping.key?(time_string) && keeping.length < keep
-          keep_reason = period
+          snapshot[:keep_reason] = period
           keeping[time_string] = snapshot
           if group_by_key
             group_bys.push(snapshot[:tags][group_by_key])
@@ -71,17 +71,24 @@ def rotate_em(snapshots)
         break
       end
     end
+  end
 
-    if group_by_key && keep_reason.nil? && group_bys.include?(snapshot[:tags][group_by_key])
-      keep_reason = "volume is associated with others by #{group_by_key}=#{snapshot[:tags][group_by_key]}"
+  snapshots.each do |snapshot|
+    if group_by_key && snapshot[:keep_reason].nil? && group_bys.include?(snapshot[:tags][group_by_key])
+      snapshot[:keep_reason] = "volume is associated with others by #{group_by_key}=#{snapshot[:tags][group_by_key]}"
     end
     
-    if keep_reason.nil? && snapshot == snapshots.last && $opts[:keep_last]
-      keep_reason = 'last snapshot'
+    if snapshot[:keep_reason].nil? && snapshot == snapshots.last && $opts[:keep_last]
+      snapshot[:keep_reason] = 'last snapshot'
     end
+  end
     
-    if !keep_reason.nil?
-      puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Keeping for #{keep_reason}"
+  snapshots.each do |snapshot|
+    snapshot_id = snapshot[:aws_id]
+    description = snapshot[:aws_description]
+    time = Time.parse(snapshot[:aws_started_at])
+    if !snapshot[:keep_reason].nil?
+      puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Keeping for #{snapshot[:keep_reason]}"
     else
       puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Deleting"
       begin


### PR DESCRIPTION
...of a raid group share (e.g. timestamp from the time before the snapshots were taken)

Example:

Snapshot 1 tags:
db=001
volume=001
timestamp=1375833666

Snapshot 2 tags:
db=001
volume=002
timestamp=1375833666

Snapshot 3 tags:
db=001
volume=003
timestamp=1375833666

--keep-hourly=24 --keep-daily=7 --keep-weekly=4 --keep-monthly=1 --by-tags db=001 --group_by=timestamp --dry-run
